### PR TITLE
WIP: Add macintosh install instructions 💻

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ $ createdb roster
 ```
 
 3. Follow instructions at <https://grpc.io/docs/quickstart/go.html> to install Protocol Buffers 3 and grpc
+<br/>Installation for [Macintosh Install Instructions](https://stackoverflow.com/a/27709931/5283424)
 
 4. Get the code
 


### PR DESCRIPTION
Hope this is a helpful addition.

Happy to add any additional detail. You may want to consolidate installation process for many operating systems in a centralized repository and have all your go projects reference that repository.

Cheers, Michael Dimmitt

looks like this mac install may be incomplete at the moment.
```bash
go get -u -fix github.com/hoop33/roster
cannot find package "google.golang.org/grpc/grpclb/grpc_lb_v1/messages
```

later on the make command:
```bash 
make
for file in $(find . -type f -name '*.proto'); do protoc -I $(dirname $file) --go_out=plugins=grpc:$(dirname $file) $file; done
/bin/sh: protoc: command not found
/bin/sh: protoc: command not found
/bin/sh: protoc: command not found
/bin/sh: protoc: command not found
/bin/sh: protoc: command not found
make: *** [proto] Error 127
```