### PR TITLE
Add macintosh install instructions 💻

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ $ createdb roster
 ```sh
 $ brew install go
 $ brew install protobuf
-$ # Add the below line to your $HOME/.bashrc
-$ export GOROOT=/usr/local/opt/go/libexec; export GOPATH=$HOME/go; export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bashrc; . $HOME/.bashrc;
+$ # Add the below line to your appropriate "rc" file for your shell: (bashrc, zshrc, .fishrc, etc)
+$ export GOPATH=$HOME/go; export PATH=$PATH:$GOPATH/bin
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ $ createdb roster
 
 ```sh
 $ brew install go
+$ brew install protobuf
+$ # Add the below line to your $HOME/.bashrc
+$ export GOROOT=/usr/local/opt/go/libexec; export GOPATH=$HOME/go; export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bashrc; . $HOME/.bashrc;
+
 ```
 
 *Note:* Older installation guides indicate setting more environment variables than necessary. The page at <https://github.com/golang/go/wiki/SettingGOPATH> contains current information on Go's environment variables.


### PR DESCRIPTION
Was able to get past the issues we were having on Thursday. See #2. 
Full disclosure: your go other repos, Jags and Limo work with no issues.

```bash
$ go version
$ go version go1.10.3 darwin/amd64 # output
```

This is the current error output when `make` is called.
```
[!] dependency not vendored: github.com/golang/protobuf/proto
[!] dependency not vendored: google.golang.org/genproto/googleapis/rpc/status
[!] dependency not vendored: github.com/golang/protobuf/ptypes/any
[!] dependency not vendored: github.com/golang/protobuf/ptypes/timestamp
[!] dependency not vendored: github.com/golang/protobuf/ptypes/duration
make: *** [vendorcheck] Error 1
```